### PR TITLE
Remove top-level item routes

### DIFF
--- a/service/api/urls.py
+++ b/service/api/urls.py
@@ -6,7 +6,5 @@ urlpatterns = [
     url(r'^collections/$', views.CollectionList.as_view(), name='collection-list'),
     url(r'^collections/(?P<pk>\w+)/$', views.CollectionDetail.as_view(), name='collection-detail'),
     url(r'^collections/(?P<pk>\w+)/items/$', views.CollectionItemList.as_view(), name='collection-items'),
-    url(r'^collections/(?P<pk>\w+)/items/(?P<item_id>\w+)/$', views.ItemDetail.as_view(), name='collection-item-detail'),
-    url(r'^items/$', views.ItemList.as_view(), name='item-list'),
-    url(r'^items/(?P<item_id>\w+)/$', views.ItemDetail.as_view(), name='item-detail'),
+    url(r'^collections/(?P<pk>\w+)/items/(?P<item_id>\w+)/$', views.ItemDetail.as_view(), name='collection-item-detail')
 ]

--- a/service/api/views.py
+++ b/service/api/views.py
@@ -35,17 +35,6 @@ class CollectionItemList(generics.ListCreateAPIView):
         return Item.objects.filter(collection=self.kwargs['pk'])
 
 
-class ItemList(generics.ListAPIView):
-    serializer_class = ItemSerializer
-
-    def get_queryset(self):
-        queryset = Item.objects.all()
-        collection_id = self.request.query_params.get('collection_id', None)
-        if collection_id is not None:
-            queryset = queryset.filter(collection=collection_id)
-        return queryset
-
-
 class ItemDetail(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = ItemSerializer
 


### PR DESCRIPTION
Since items must belong to a collection, the `/items` and `/items/<item_id>` routes are not needed.