### PR TITLE
[OC-8] Fix item date added and date submitted

### DIFF
--- a/service/api/models.py
+++ b/service/api/models.py
@@ -23,3 +23,4 @@ class Item(models.Model):
     is_displayed = models.BooleanField(default=True)
     metadata = models.TextField()
     date_added = models.DateTimeField(null=True, blank=True, default=None)
+    date_submitted = models.DateTimeField(auto_now_add=True)

--- a/service/api/models.py
+++ b/service/api/models.py
@@ -22,4 +22,4 @@ class Item(models.Model):
     created_by = models.ForeignKey(User)
     is_displayed = models.BooleanField(default=True)
     metadata = models.TextField()
-    date_added = models.DateTimeField()
+    date_added = models.DateTimeField(null=True, blank=True, default=None)

--- a/service/api/serializers.py
+++ b/service/api/serializers.py
@@ -1,3 +1,4 @@
+import datetime
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 from models import Collection, Item, User
@@ -30,7 +31,7 @@ class ItemSerializer(serializers.Serializer):
     created_by = UserSerializer(read_only=True)
     is_displayed = serializers.BooleanField()
     metadata = serializers.CharField(allow_blank=True)
-    date_added = serializers.DateTimeField()
+    date_added = serializers.DateTimeField(read_only=True, allow_null=True)
 
     class Meta:
         model = Item
@@ -39,6 +40,8 @@ class ItemSerializer(serializers.Serializer):
         user = self.context['request'].user
         collection_id = self.context['request'].parser_context['kwargs'].get('pk', None)
         collection = Collection.objects.get(id=collection_id)
+        if validated_data['status'] == 'approved':
+            validated_data['date_added'] = datetime.datetime.now()
         item = Item.objects.create(
             created_by=user,
             collection=collection,

--- a/service/api/serializers.py
+++ b/service/api/serializers.py
@@ -32,6 +32,7 @@ class ItemSerializer(serializers.Serializer):
     is_displayed = serializers.BooleanField()
     metadata = serializers.CharField(allow_blank=True)
     date_added = serializers.DateTimeField(read_only=True, allow_null=True)
+    date_submitted = serializers.DateTimeField(read_only=True)
 
     class Meta:
         model = Item


### PR DESCRIPTION
Ticket: https://openscience.atlassian.net/browse/OC-8

Include both a `date_added` (when the item was approved) and `date_submitted` (when the item was created/submitted to the collection) field on the Item model.