### PR TITLE
Remove "group selected" from group page [OC-31]

### DIFF
--- a/client/app/templates/collection/group/index.hbs
+++ b/client/app/templates/collection/group/index.hbs
@@ -16,7 +16,6 @@
         <div class="row">
             <div class="col-xs-6">
                 {{#if organizeMode}}
-                    <button class="btn btn-default" {{action 'groupSelected'}}>Group Selected</button>
                     <button class="btn btn-danger" {{action 'deleteSelected'}}>Delete selected </button>
                 {{/if}}
             </div>


### PR DESCRIPTION
Remove "group selected" from group page since groups cannot contain other groups