### PR TITLE
Add top-level item and group routes [OC-36][OC-37]

### DIFF
--- a/service/api/serializers.py
+++ b/service/api/serializers.py
@@ -132,7 +132,7 @@ class CollectionSerializer(serializers.Serializer):
     date_created = serializers.DateTimeField(read_only=True)
     date_updated = serializers.DateTimeField(read_only=True)
     groups = RelationshipField(
-        related_view='group-list',
+        related_view='collection-group-list',
         related_view_kwargs={'pk': '<pk>'}
     )
     items = RelationshipField(

--- a/service/api/urls.py
+++ b/service/api/urls.py
@@ -5,12 +5,15 @@ urlpatterns = [
     url(r'^$', views.api_root),
     url(r'^collections/$', views.CollectionList.as_view(), name='collection-list'),
     url(r'^collections/(?P<pk>\w+)/$', views.CollectionDetail.as_view(), name='collection-detail'),
-    url(r'^collections/(?P<pk>\w+)/groups/$', views.GroupList.as_view(), name='group-list'),
-    url(r'^collections/(?P<pk>\w+)/groups/(?P<group_id>\w+)/$', views.GroupDetail.as_view(), name='group-detail'),
+    url(r'^collections/(?P<pk>\w+)/groups/$', views.GroupList.as_view(), name='collection-group-list'),
+    url(r'^collections/(?P<pk>\w+)/groups/(?P<group_id>\w+)/$', views.GroupDetail.as_view(), name='collection-group-detail'),
     url(r'^collections/(?P<pk>\w+)/groups/(?P<group_id>\w+)/items/$', views.GroupItemList.as_view(), name='group-item-list'),
     url(r'^collections/(?P<pk>\w+)/groups/(?P<group_id>\w+)/items/(?P<item_id>\w+)/$', views.ItemDetail.as_view(), name='group-item-detail'),
     url(r'^collections/(?P<pk>\w+)/items/$', views.CollectionItemList.as_view(), name='collection-item-list'),
     url(r'^collections/(?P<pk>\w+)/items/(?P<item_id>\w+)/$', views.ItemDetail.as_view(), name='collection-item-detail'),
+
+    url(r'^groups/$', views.GroupList.as_view(), name='group-list'),
+    url(r'^groups/(?P<group_id>\w+)/$', views.GroupDetail.as_view(), name='group-detail'),
 
     url(r'^items/$', views.ItemList.as_view(), name='item-list'),
     url(r'^items/(?P<item_id>\w+)/$', views.ItemDetail.as_view(), name='item-detail')

--- a/service/api/urls.py
+++ b/service/api/urls.py
@@ -11,4 +11,7 @@ urlpatterns = [
     url(r'^collections/(?P<pk>\w+)/groups/(?P<group_id>\w+)/items/(?P<item_id>\w+)/$', views.ItemDetail.as_view(), name='group-item-detail'),
     url(r'^collections/(?P<pk>\w+)/items/$', views.CollectionItemList.as_view(), name='collection-item-list'),
     url(r'^collections/(?P<pk>\w+)/items/(?P<item_id>\w+)/$', views.ItemDetail.as_view(), name='collection-item-detail'),
+
+    url(r'^items/$', views.ItemList.as_view(), name='item-list'),
+    url(r'^items/(?P<item_id>\w+)/$', views.ItemDetail.as_view(), name='item-detail')
 ]

--- a/service/api/views.py
+++ b/service/api/views.py
@@ -101,3 +101,12 @@ class CollectionItemList(generics.ListCreateAPIView):
         if user.id == collection.created_by_id:
             return queryset
         return queryset.filter(Q(status='approved') | Q(created_by=user.id))
+
+
+class ItemList(generics.ListAPIView):
+    serializer_class = ItemSerializer
+    permission_classes = (drf_permissions.IsAuthenticatedOrReadOnly, )
+
+    def get_queryset(self):
+        user = self.request.user
+        return Item.objects.filter(Q(status='approved') | Q(created_by=user.id) | Q(collection__created_by=user.id))

--- a/service/api/views.py
+++ b/service/api/views.py
@@ -45,7 +45,7 @@ class GroupList(generics.ListCreateAPIView):
     serializer_class = GroupSerializer
     permission_classes = (
       drf_permissions.IsAuthenticatedOrReadOnly,
-      CanEditCollection
+      CanEditGroup
     )
 
     def get_queryset(self):

--- a/service/api/views.py
+++ b/service/api/views.py
@@ -49,7 +49,10 @@ class GroupList(generics.ListCreateAPIView):
     )
 
     def get_queryset(self):
-        return Group.objects.filter(collection=self.kwargs['pk'])
+        groups = Group.objects.all()
+        if self.kwargs.get('pk', None):
+            return groups.filter(collection=self.kwargs['pk'])
+        return groups
 
 
 class GroupDetail(generics.RetrieveUpdateDestroyAPIView):


### PR DESCRIPTION
Add the following API routes to make it easier to get the data into ember:
- `groups/`
- `groups/<group_id>/`
- `items/`
- `items/<item_id>`
