### PR TITLE
Delete collection items [OC-32]

### DIFF
--- a/client/app/adapters/group.js
+++ b/client/app/adapters/group.js
@@ -1,8 +1,4 @@
-import Application from './application';
+import CollectionAdapter from './collection';
 
-export default Application.extend({
-    buildURL(collection, id, snapshot, requestType) {
-        let collectionId = snapshot.record.belongsTo('collection').parent._id;
-        return this.get('host') + '/api/collections/' + collectionId + '/groups/' + id + '/';
-    }
+export default CollectionAdapter.extend({
 });

--- a/client/app/adapters/item.js
+++ b/client/app/adapters/item.js
@@ -1,8 +1,4 @@
-import Application from './application';
+import CollectionAdapter from './collection';
 
-export default Application.extend({
-    buildURL(_, __, ___, requestType) {
-        // Embed linked_nodes
-        return this.get('host') + '/api/collections/' + ___.record.get('collection').get('id') + '/items/';
-    }
+export default CollectionAdapter.extend({
 });

--- a/client/app/controllers/collection/index.js
+++ b/client/app/controllers/collection/index.js
@@ -21,15 +21,6 @@ export default Ember.Controller.extend({
       return groups;
     }),
     list: Ember.computed.union('groups', 'model.items'),
-    clearSelected(){
-        let selected = this.get('selectedItems');
-        selected.clear();
-    },
-    clearModals (){
-        this.set('showGroupConfirmation', false);
-        this.set('showDeleteConfirmation', false);
-        this.set('groupTitle', '');
-    },
     actions: {
         findNode () {
             let self = this;
@@ -51,11 +42,25 @@ export default Ember.Controller.extend({
         toggleDeleteConfirmation(){
             this.toggleProperty('showDeleteConfirmation');
         },
+        clearSelected() {
+            let selected = this.get('selectedItems');
+            selected.clear();
+        },
+        clearModals() {
+            this.set('showGroupConfirmation', false);
+            this.set('showDeleteConfirmation', false);
+            this.set('groupTitle', '');
+        },
         deleteSelected(){
             let items = this.get('list');
-            items.removeObjects(this.get('selectedItems'));
-            this.clearSelected();
-            this.clearModals();
+            let selected = this.get('selectedItems');
+            selected.forEach(item =>
+                Ember.run.once(() =>
+                  item.destroyRecord()
+            ));
+            items.removeObjects(selected);
+            this.send('clearSelected');
+            this.send('clearModals');
         },
         toggleGroupConfirmation ( ){
             this.toggleProperty('showGroupConfirmation');
@@ -75,8 +80,8 @@ export default Ember.Controller.extend({
             let items = this.get('list');
             let selected = this.get('selectedItems');
             items.removeObjects(selected);
-            this.clearSelected();
-            this.clearModals();
+            this.send('clearSelected');
+            this.send('clearModals');
         },
         // Adds or removes item to the selectedItems list
         toggleSelectedList(selected, item){


### PR DESCRIPTION
- Add ability to delete items from a collection
- Make group and item adapters extend the collection adapter so that a trailing slash is appended to the end of the urls that ember uses. Without the trailing slash, the DRF API will throw an error.
