### PR TITLE
Feature: Fix API routes

### DIFF
--- a/service/api/serializers.py
+++ b/service/api/serializers.py
@@ -106,7 +106,7 @@ class GroupSerializer(serializers.Serializer):
 
     def create(self, validated_data):
         user = self.context['request'].user
-        collection_id = self.context['request'].parser_context['kwargs'].get('pk', None)
+        collection_id = self.context.get('collection_id', None) or self.context['request'].parser_context['kwargs'].get('pk', None)
         collection = Collection.objects.get(id=collection_id)
         return Group.objects.create(
             created_by=user,

--- a/service/api/serializers.py
+++ b/service/api/serializers.py
@@ -48,9 +48,9 @@ class ItemSerializer(serializers.Serializer):
 
     def create(self, validated_data):
         user = self.context['request'].user
-        collection_id = self.context['request'].parser_context['kwargs'].get('pk', None)
+        collection_id = self.context.get('collection_id', None) or self.context['request'].parser_context['kwargs'].get('pk', None)
         collection = Collection.objects.get(id=collection_id)
-        group_id = self.context['request'].parser_context['kwargs'].get('group_id', None)
+        group_id = self.context.get('group_id', None) or self.context['request'].parser_context['kwargs'].get('group_id', None)
         if group_id:
             validated_data['group'] = Group.objects.get(id=group_id)
         status = 'pending'

--- a/service/api/urls.py
+++ b/service/api/urls.py
@@ -5,7 +5,7 @@ urlpatterns = [
     url(r'^$', views.api_root),
     url(r'^collections/$', views.CollectionList.as_view(), name='collection-list'),
     url(r'^collections/(?P<pk>\w+)/$', views.CollectionDetail.as_view(), name='collection-detail'),
-    url(r'^collections/(?P<pk>\w+)/groups/$', views.GroupList.as_view(), name='collection-group-list'),
+    url(r'^collections/(?P<pk>\w+)/groups/$', views.CollectionGroupList.as_view(), name='collection-group-list'),
     url(r'^collections/(?P<pk>\w+)/groups/(?P<group_id>\w+)/$', views.GroupDetail.as_view(), name='collection-group-detail'),
     url(r'^collections/(?P<pk>\w+)/groups/(?P<group_id>\w+)/items/$', views.GroupItemList.as_view(), name='group-item-list'),
     url(r'^collections/(?P<pk>\w+)/groups/(?P<group_id>\w+)/items/(?P<item_id>\w+)/$', views.ItemDetail.as_view(), name='group-item-detail'),

--- a/service/api/views.py
+++ b/service/api/views.py
@@ -106,9 +106,18 @@ class CollectionItemList(generics.ListCreateAPIView):
         return queryset.filter(Q(status='approved') | Q(created_by=user.id))
 
 
-class ItemList(generics.ListAPIView):
+class ItemList(generics.ListCreateAPIView):
     serializer_class = ItemSerializer
     permission_classes = (drf_permissions.IsAuthenticatedOrReadOnly, )
+
+    def get_serializer_context(self):
+        context = super(ItemList, self).get_serializer_context()
+        collection = self.request.data.get('collection', None)
+        context.update({'collection_id': collection['id']})
+        group = self.request.data.get('group', None)
+        if group:
+            context.update({'group_id': group['id']})
+        return context
 
     def get_queryset(self):
         user = self.request.user

--- a/service/api/views.py
+++ b/service/api/views.py
@@ -134,5 +134,14 @@ class ItemDetail(generics.RetrieveUpdateDestroyAPIView):
       CanEditItem
     )
 
+    def get_serializer_context(self):
+        context = super(ItemDetail, self).get_serializer_context()
+        collection = self.request.data.get('collection', None)
+        context.update({'collection_id': collection['id']})
+        group = self.request.data.get('group', None)
+        if group:
+            context.update({'group_id': group['id']})
+        return context
+
     def get_object(self):
         return Item.objects.get(id=self.kwargs['item_id'])


### PR DESCRIPTION
Fix top-level API routes for creating/updating items and groups. 

- Make items route a ListCreateAPIView and pass the collection and group ids from the request payload to the serializer.
- Add ability to update item group
- Pass group id in from request when creating a group through the `groups/` route