### PR TITLE
Delete groups from collection [OC-34]

### DIFF
--- a/client/app/controllers/collection/group/index.js
+++ b/client/app/controllers/collection/group/index.js
@@ -15,7 +15,15 @@ export default Ember.Controller.extend({
               this.set('showDeleteItemConfirmation', false);
           },
         deletePartial(){
-            // for the moment this will do the same as deletefull.
+            let collection = this.get('model.collection');
+            let items = this.get('model.items');
+            items.forEach(item => {
+                item.set('group', null);
+                item.save();
+            });
+            this.get('model').destroyRecord().then(() =>
+              this.transitionToRoute('collection', collection)
+            );
         },
         deleteFull(){
             let collection = this.get('model.collection');

--- a/client/app/controllers/collection/group/index.js
+++ b/client/app/controllers/collection/group/index.js
@@ -15,18 +15,16 @@ export default Ember.Controller.extend({
               this.set('showDeleteItemConfirmation', false);
           },
         deletePartial(){
-            let collection = this.get('model.collection');
+            // Move items to collection before deleting group
             let items = this.get('model.items');
             items.forEach(item => {
                 item.set('group', null);
                 item.save();
             });
-            this.get('model').destroyRecord().then(() =>
-              this.transitionToRoute('collection', collection)
-            );
-            this.send('clearModals');
+            this.sendAction('deleteGroup');
         },
-        deleteFull(){
+        deleteGroup(){
+            // Delete group and any items it contains
             let collection = this.get('model.collection');
             this.get('model').destroyRecord().then(() =>
               this.transitionToRoute('collection', collection)

--- a/client/app/controllers/collection/group/index.js
+++ b/client/app/controllers/collection/group/index.js
@@ -24,12 +24,14 @@ export default Ember.Controller.extend({
             this.get('model').destroyRecord().then(() =>
               this.transitionToRoute('collection', collection)
             );
+            this.send('clearModals');
         },
         deleteFull(){
             let collection = this.get('model.collection');
             this.get('model').destroyRecord().then(() =>
               this.transitionToRoute('collection', collection)
             );
+            this.send('clearModals');
         },
         deleteSelected() {
             let items = this.get('model.items');

--- a/client/app/controllers/collection/group/index.js
+++ b/client/app/controllers/collection/group/index.js
@@ -18,7 +18,10 @@ export default Ember.Controller.extend({
             // for the moment this will do the same as deletefull.
         },
         deleteFull(){
-
+            let collection = this.get('model.collection');
+            this.get('model').destroyRecord().then(() =>
+              this.transitionToRoute('collection', collection)
+            );
         },
         deleteSelected() {
             let items = this.get('model.items');

--- a/client/app/templates/collection/group/index.hbs
+++ b/client/app/templates/collection/group/index.hbs
@@ -62,7 +62,7 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" aria-label="Close" {{action toggleProperty 'showDeleteConfirmation'}}><span aria-hidden="true">&times;</span></button>
+        <button type="button" class="close" aria-label="Close" {{action toggleProperty 'showDeleteGroupConfirmation'}}><span aria-hidden="true">&times;</span></button>
         <h4 class="modal-title">Delete this group?</h4>
       </div>
       <div class="modal-body">
@@ -70,7 +70,7 @@
         <p>You can delete the group and keep items. This option will put the items back into the collection.</p>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-default" {{action toggleProperty 'showDeleteConfirmation'}}>Close</button>
+        <button type="button" class="btn btn-default" {{action toggleProperty 'showDeleteGroupConfirmation'}}>Close</button>
         <button type="button" class="btn btn-warning" {{action 'deletePartial'}}>Delete Group and keep items</button>
         <button type="button" class="btn btn-danger" {{action 'deleteFull'}}>Delete all</button>
 

--- a/service/api/serializers.py
+++ b/service/api/serializers.py
@@ -81,8 +81,11 @@ class ItemSerializer(serializers.Serializer):
 
         group_id = self.context.get('group_id', None) or self.context['request'].parser_context['kwargs'].get('group_id', None)
         if group_id:
-            item.group = Group.objects.get(id=group_id)
+            group = Group.objects.get(id=group_id)
+        else:
+            group = None
 
+        item.group = group
         item.source_id = validated_data.get('source_id', item.source_id)
         item.title = validated_data.get('title', item.title)
         item.type = validated_data.get('type', item.type)

--- a/service/api/views.py
+++ b/service/api/views.py
@@ -143,6 +143,9 @@ class ItemDetail(generics.RetrieveUpdateDestroyAPIView):
         group = self.request.data.get('group', None)
         if group:
             context.update({'group_id': group['id']})
+        else:
+            context.update({'group_id': None})
+
         return context
 
     def get_object(self):


### PR DESCRIPTION
- Add functionality for deleting a group and all of its items
- Add functionality for deleting a group and moving all of its items to the collection
- Change the API item update method so that if a group is not specified in the request payload (for the top-level `items/<item_detail>` route), it will get set to None