### PR TITLE
Feature: Display collection creator name [OC-39][OC-47]

### DIFF
--- a/client/app/components/collection-detail/template.hbs
+++ b/client/app/components/collection-detail/template.hbs
@@ -35,7 +35,7 @@
                 <span class="coll-item-tag">{{tag}}</span>
             {{/each}}
         </div>
-        <p>Created by: {{model.created_by.username}} </p>
+        <p>Created by: {{model.created_by.fullName}} </p>
         <p>Date created: {{model.dateCreated}} </p>
         <p>Date updated : {{model.dateUpdated}}</p>
         <div class="pull-right">

--- a/service/api/models.py
+++ b/service/api/models.py
@@ -1,6 +1,10 @@
 from __future__ import unicode_literals
 from django.db import models
-from django.contrib.auth.models import User
+from django.contrib.auth.models import AbstractUser
+
+
+class User(AbstractUser):
+    id = models.TextField(primary_key=True)
 
 
 class Collection(models.Model):

--- a/service/api/renderers.py
+++ b/service/api/renderers.py
@@ -27,11 +27,12 @@ class CustomJSONRenderer(JSONRenderer):
                 data.update({field_name: resource.get(field_name)})
         # Remove embedded relationship data
         for field in data:
-            ret = {}
-            for key in data[field]:
-                if key != 'data':
-                    ret[key] = data[field][key]
-            data[field] = ret
+            if isinstance(field, RelationshipField):
+                ret = {}
+                for key in data[field]:
+                    if key != 'data':
+                        ret[key] = data[field][key]
+                data[field] = ret
         return utils.format_keys(data)
 
     @staticmethod

--- a/service/api/urls.py
+++ b/service/api/urls.py
@@ -17,5 +17,4 @@ urlpatterns = [
 
     url(r'^items/$', api.views.ItemList.as_view(), name='item-list'),
     url(r'^items/(?P<item_id>\w+)/$', api.views.ItemDetail.as_view(), name='item-detail'),
-    url(r'^collections/(?P<pk>\w+)/owner/$', api.views.CollectionUserDetail.as_view(), name='collection-user'),
 ]

--- a/service/api/views.py
+++ b/service/api/views.py
@@ -150,12 +150,3 @@ class ItemDetail(generics.RetrieveUpdateDestroyAPIView):
 
     def get_object(self):
         return Item.objects.get(id=self.kwargs['item_id'])
-
-
-class CollectionUserDetail(generics.RetrieveAPIView):
-    serializer_class = UserSerializer
-    permission_classes = (drf_permissions.IsAuthenticatedOrReadOnly, )
-
-    def get_object(self):
-        collection = Collection.objects.get(id=self.kwargs['pk'])
-        return User.objects.get(id=collection.created_by_id)

--- a/service/auth/authentication.py
+++ b/service/auth/authentication.py
@@ -1,7 +1,8 @@
-from django.contrib.auth.models import User
-from rest_framework import authentication
-from django.core.exceptions import ObjectDoesNotExist
 import requests
+from django.core.exceptions import ObjectDoesNotExist
+from django.contrib.auth import get_user_model
+from rest_framework import authentication
+
 
 class OSFAuthentication(authentication.BaseAuthentication):
     def authenticate(self, request):
@@ -15,10 +16,10 @@ class OSFAuthentication(authentication.BaseAuthentication):
             return None
 
         user_id = osf_user.json()['data']['id']
-
+        user_model = get_user_model()
         try:
-            user = User.objects.get(username=user_id)
+            user = user_model.objects.get(id=user_id, username=user_id)
         except ObjectDoesNotExist:
-            user = User.objects.create_user(username=user_id)
+            user = user_model.objects.create_user(id=user_id, username=user_id)
 
         return (user, None)

--- a/service/service/settings/base.py
+++ b/service/service/settings/base.py
@@ -21,6 +21,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    'api.apps.ApiConfig',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -28,7 +29,6 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
-    'api.apps.ApiConfig',
     'corsheaders',
 ]
 
@@ -135,3 +135,5 @@ CORS_ALLOW_CREDENTIALS = True
 CORS_ORIGIN_WHITELIST = (
     'localhost:4200'
 )
+
+AUTH_USER_MODEL = 'api.User'


### PR DESCRIPTION
Purpose:
Show the name of the collection creator on the collection detail page

Changes:
- Use a custom user model where `id` is the guid of the OSF user, instead of an auto-generated one. This way, when ember is making a request to the OSF API to get the related user data it will find the right user instead of throwing a 404 error.
- Update the JSON API renderer so that embedded data is only removed from RelationshipField fields (and not Serializer fields) to fix `created_by` serialization 