### PR TITLE
Feature: Make item.type and item.status choice fields [OC-48]

### DIFF
--- a/service/api/models.py
+++ b/service/api/models.py
@@ -35,9 +35,16 @@ class Group(models.Model):
 
 
 class Item(models.Model):
+    TYPES = (
+        ('project', 'project'),
+        ('preprint', 'preprint'),
+        ('registration', 'registration'),
+        ('file', 'file'),
+        ('website', 'website')
+    )
     source_id = models.TextField()
     title = models.TextField()
-    type = models.TextField()
+    type = models.TextField(choices=TYPES)
     status = models.TextField()
     url = models.URLField()
     collection = models.ForeignKey(to='Collection', related_name='items')

--- a/service/api/models.py
+++ b/service/api/models.py
@@ -42,10 +42,15 @@ class Item(models.Model):
         ('file', 'file'),
         ('website', 'website')
     )
+    STATUS = (
+        ('approved', 'approved'),
+        ('pending', 'pending'),
+        ('rejected', 'rejected')
+    )
     source_id = models.TextField()
     title = models.TextField()
     type = models.TextField(choices=TYPES)
-    status = models.TextField()
+    status = models.TextField(choices=STATUS)
     url = models.URLField()
     collection = models.ForeignKey(to='Collection', related_name='items')
     group = models.ForeignKey(to='Group', null=True, blank=True, default=None, related_name='items')

--- a/service/api/serializers.py
+++ b/service/api/serializers.py
@@ -29,7 +29,7 @@ class ItemSerializer(serializers.Serializer):
     id = serializers.CharField(read_only=True)
     source_id = serializers.CharField()
     title = serializers.CharField(required=True)
-    type = serializers.CharField()
+    type = serializers.ChoiceField(choices=['project', 'preprint', 'registration', 'file', 'website'])
     status = serializers.CharField()
     url = serializers.URLField()
     created_by = UserSerializer(read_only=True)

--- a/service/api/serializers.py
+++ b/service/api/serializers.py
@@ -30,7 +30,7 @@ class ItemSerializer(serializers.Serializer):
     source_id = serializers.CharField()
     title = serializers.CharField(required=True)
     type = serializers.ChoiceField(choices=['project', 'preprint', 'registration', 'file', 'website'])
-    status = serializers.CharField()
+    status = serializers.ChoiceField(choices=['approved', 'pending', 'rejected'])
     url = serializers.URLField()
     created_by = UserSerializer(read_only=True)
     metadata = serializers.CharField(allow_blank=True)

--- a/service/service/settings/base.py
+++ b/service/service/settings/base.py
@@ -123,6 +123,7 @@ REST_FRAMEWORK = {
     'DEFAULT_METADATA_CLASS': 'rest_framework_json_api.metadata.JSONAPIMetadata',
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'auth.authentication.OSFAuthentication',
+        'rest_framework.authentication.SessionAuthentication'
     )
 }
 


### PR DESCRIPTION
Add`choices` to `item.type` field and make the serializer field a `ChoiceField` since there are certain types an item can have (currently "project", "preprint", "registration", "file" or "website". Same with `item.status`, which currently can only be "approved", "pending" or "rejected".

Also fix loggin into the DRF browsable API by adding `'rest_framework.authentication.SessionAuthentication'` to the DRF `DEFAULT_AUTHENTICATION_CLASSES`