### PR TITLE
Only show "Organize items" button when a collection or group has items [OC-49]

### DIFF
--- a/client/app/templates/collection/group/index.hbs
+++ b/client/app/templates/collection/group/index.hbs
@@ -10,14 +10,16 @@
 <div class="coll-items">
     <div class="container">
         <div class="row">
-            <div class="col-xs-6">
-                {{#if organizeMode}}
-                    <button class="btn btn-danger" {{action toggleProperty 'showDeleteItemConfirmation'}}>Delete selected </button>
-                {{/if}}
-            </div>
-            <div class="col-xs-6 text-right">
-                <button class="btn btn-info" {{action toggleProperty 'organizeMode'}}>Organize Items </button>
-            </div>
+            {{#if model.items}}
+                <div class="col-xs-6">
+                    {{#if organizeMode}}
+                        <button class="btn btn-danger" {{action toggleProperty 'showDeleteItemConfirmation'}}>Delete selected </button>
+                    {{/if}}
+                </div>
+                <div class="col-xs-6 text-right">
+                    <button class="btn btn-info" {{action toggleProperty 'organizeMode'}}>Organize Items </button>
+                </div>
+           {{/if}}
         </div>
         <div class="row">
             {{#each model.items as |item|}}

--- a/client/app/templates/collection/index.hbs
+++ b/client/app/templates/collection/index.hbs
@@ -2,19 +2,21 @@
 <div class="coll-items">
     <div class="container">
         <div class="row">
-            <div class="col-xs-6">
-                {{#if organizeMode}}
-                    <button class="btn btn-default" {{action 'toggleGroupConfirmation'}}>Group Selected</button>
-                    <button class="btn btn-danger" {{action 'toggleDeleteConfirmation'}}>Delete selected </button>
-                {{/if}}
-            </div>
-            <div class="col-xs-6 text-right">
-                {{#if organizeMode}}
-                    <button class="btn btn-default" {{action 'toggleOrganizeMode'}}>Cancel organizing </button>
-                {{else}}
-                    <button class="btn btn-info" {{action 'toggleOrganizeMode'}}>Organize Items </button>
-                {{/if}}
-            </div>
+            {{#if list}}
+                <div class="col-xs-6">
+                    {{#if organizeMode}}
+                        <button class="btn btn-default" {{action 'toggleGroupConfirmation'}}>Group Selected</button>
+                        <button class="btn btn-danger" {{action 'toggleDeleteConfirmation'}}>Delete selected </button>
+                    {{/if}}
+                </div>
+                <div class="col-xs-6 text-right">
+                    {{#if organizeMode}}
+                        <button class="btn btn-default" {{action 'toggleOrganizeMode'}}>Cancel organizing </button>
+                    {{else}}
+                        <button class="btn btn-info" {{action 'toggleOrganizeMode'}}>Organize Items </button>
+                    {{/if}}
+                </div>
+            {{/if}}
         </div>
         <div class="row">
             {{#if list}}


### PR DESCRIPTION
Hide the "organize items" button on the collection detail page when the collection is empty, since there are no items to organize. Same for the group detail page.