### PR TITLE
Feature: Add table view for collection  [OC-53]

### DIFF
--- a/client/app/components/collection-item/component.js
+++ b/client/app/components/collection-item/component.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
     tagName: null,
+    classNameBindings: ['selected:item-row-selected'],
     cardView: true,
     item: null,
     selected: false,

--- a/client/app/components/collection-item/component.js
+++ b/client/app/components/collection-item/component.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+    tagName: null,
+    view: null,
     item: null,
     selected: false,
     actions : {

--- a/client/app/components/collection-item/component.js
+++ b/client/app/components/collection-item/component.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
     tagName: null,
-    view: null,
+    cardView: true,
     item: null,
     selected: false,
     actions : {

--- a/client/app/components/collection-item/template.hbs
+++ b/client/app/components/collection-item/template.hbs
@@ -1,23 +1,44 @@
-<div class="coll-item-wrapper">
-    {{#if organizeMode}}
-        {{#unless (eq item.type 'group')}}
-            <div class="coll-item-organize {{if selected 'item-selected'}}" {{action 'markSelected' item}}>
-                <i class="fa fa-check"></i>
-                <p>{{if selected 'Click to unselect' 'Click to select'}}</p>
-            </div>
-        {{/unless}}
-    {{/if}}
-    <div class="coll-item coll-item-type-{{item.type}} {{if (eq item.type 'group') 'coll-item-isgroup'}}">
-        {{#if (eq item.type 'group')}}
-            <h3>{{#link-to 'collection.group' item.id}}{{item.title}}{{/link-to}}</h3>
-        {{else if (eq parent 'group')}}
-            <h3>{{#link-to 'collection.group.item' item.id}}{{item.title}}{{/link-to}}</h3>
-        {{else}}
-            <h3>{{#link-to 'collection.item' item.id}}{{item.title}}{{/link-to}}</h3>
+{{#if (eq view 'cards')}}
+    <div class="coll-item-wrapper">
+        {{#if organizeMode}}
+            {{#unless (eq item.type 'group')}}
+                <div class="coll-item-organize {{if selected 'item-selected'}}" {{action 'markSelected' item}}>
+                    <i class="fa fa-check"></i>
+                    <p>{{if selected 'Click to unselect' 'Click to select'}}</p>
+                </div>
+            {{/unless}}
         {{/if}}
-        <p> Type: {{item.type}} </p>
-        {{#if item.status}}
-            <p> Status: {{item.status}} </p>
-        {{/if}}
+        <div class="coll-item coll-item-type-{{item.type}} {{if (eq item.type 'group') 'coll-item-isgroup'}}">
+            {{#if (eq item.type 'group')}}
+                <h3>{{#link-to 'collection.group' item.id}}{{item.title}}{{/link-to}}</h3>
+            {{else if (eq parent 'group')}}
+                <h3>{{#link-to 'collection.group.item' item.id}}{{item.title}}{{/link-to}}</h3>
+            {{else}}
+                <h3>{{#link-to 'collection.item' item.id}}{{item.title}}{{/link-to}}</h3>
+            {{/if}}
+            <p> Type: {{item.type}} </p>
+            {{#if item.status}}
+                <p> Status: {{item.status}} </p>
+            {{/if}}
+        </div>
     </div>
-</div>
+{{else if (eq view 'table')}}
+    <td>
+        {{#if (eq item.type 'group')}}
+            <p>{{#link-to 'collection.group' item.id}}{{item.title}}{{/link-to}}</p>
+        {{else if (eq parent 'group')}}
+            <p>{{#link-to 'collection.group.item' item.id}}{{item.title}}{{/link-to}}</p>
+        {{else}}
+            <p>{{#link-to 'collection.item' item.id}}{{item.title}}{{/link-to}}</p>
+        {{/if}}
+    </td>
+    <td>{{item.type}}</td>
+    <td>{{item.status}}</td>
+    <td>
+        {{#if organizeMode}}
+            {{#unless (eq item.type 'group')}}
+                {{input checked=selected type="checkbox" click=(action 'markSelected' item)}}
+            {{/unless}}
+        {{/if}}
+    </td>
+{{/if}}

--- a/client/app/components/collection-item/template.hbs
+++ b/client/app/components/collection-item/template.hbs
@@ -1,4 +1,4 @@
-{{#if (eq view 'cards')}}
+{{#if cardView}}
     <div class="coll-item-wrapper">
         {{#if organizeMode}}
             {{#unless (eq item.type 'group')}}
@@ -22,7 +22,7 @@
             {{/if}}
         </div>
     </div>
-{{else if (eq view 'table')}}
+{{else}}
     <td>
         {{#if (eq item.type 'group')}}
             <p>{{#link-to 'collection.group' item.id}}{{item.title}}{{/link-to}}</p>

--- a/client/app/controllers/collection/group/index.js
+++ b/client/app/controllers/collection/group/index.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
     organizeMode: false,
+    cardView: true,
     selectedItems : Ember.A(),
     showDeleteItemConfirmation: false, // Modal for deleting items
     actions : {
@@ -35,6 +36,9 @@ export default Ember.Controller.extend({
         },
         changeRoute(path){
             this.transitionToRoute(path);
+        },
+        changeView(cardView) {
+            this.set('cardView', cardView);
         }
     }
 });

--- a/client/app/controllers/collection/index.js
+++ b/client/app/controllers/collection/index.js
@@ -3,6 +3,7 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
     loadingGuid: false,
     organizeMode: false,
+    view: 'cards',
     selectedItems : Ember.A(), // List of items selected for actions like delete
     showDeleteConfirmation: false, // Modal for deleting items
     showGroupConfirmation: false, // Modal for grouping

--- a/client/app/controllers/collection/index.js
+++ b/client/app/controllers/collection/index.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
     loadingGuid: false,
     organizeMode: false,
-    view: 'cards',
+    cardView: true,
     selectedItems : Ember.A(), // List of items selected for actions like delete
     showDeleteConfirmation: false, // Modal for deleting items
     showGroupConfirmation: false, // Modal for grouping
@@ -95,8 +95,8 @@ export default Ember.Controller.extend({
         changeRoute(path){
             this.transitionToRoute(path);
         },
-        changeView(viewName) {
-            this.set('view', viewName);
+        changeView(cardView) {
+            this.set('cardView', cardView);
         }
     }
 });

--- a/client/app/controllers/collection/index.js
+++ b/client/app/controllers/collection/index.js
@@ -94,6 +94,9 @@ export default Ember.Controller.extend({
         },
         changeRoute(path){
             this.transitionToRoute(path);
+        },
+        changeView(viewName) {
+            this.set('view', viewName);
         }
     }
 });

--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -164,6 +164,10 @@ ul.comma-list {
     }
 }
 
+tr.item-row-selected {
+  background-color: #dff0d8;
+}
+
 .coll-item-isgroup {
     background-color: #eee;
     box-shadow:

--- a/client/app/templates/collection/group/index.hbs
+++ b/client/app/templates/collection/group/index.hbs
@@ -11,13 +11,41 @@
                 </div>
                 <div class="col-xs-6 text-right">
                     <button class="btn btn-info" {{action toggleProperty 'organizeMode'}}>Organize Items </button>
+                    <div class="btn-group">
+                        <button class="btn {{if cardView 'btn-info' 'btn-default'}}" {{action 'changeView' true}}>
+                            <i class="fa fa-th"></i>
+                        </button>
+                        <button class="btn {{unless cardView 'btn-info' 'btn-default'}}" {{action 'changeView' false}}>
+                            <i class="fa fa-list"></i>
+                        </button>
+                    </div>
                 </div>
            {{/if}}
         </div>
         <div class="row">
-            {{#each model.items as |item|}}
-                {{collection-item item=item parent='group' toggleSelectedList=(action 'toggleSelectedList') organizeMode=organizeMode class="col-sm-6 col-lg-4"}}
-            {{/each}}
+            {{#if model.items}}
+                {{#if cardView}}
+                    {{#each model.items as |item|}}
+                        {{collection-item item=item parent='group' toggleSelectedList=(action 'toggleSelectedList') organizeMode=organizeMode class="col-sm-6 col-lg-4"}}
+                    {{/each}}
+                {{else}}
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>Title</th>
+                                <th>Type</th>
+                                <th>Status</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {{#each model.items as |item|}}
+                                {{collection-item item=item cardView=cardView tagName='tr' parent='group' toggleSelectedList=(action 'toggleSelectedList') organizeMode=organizeMode}}
+                            {{/each}}
+                        </tbody>
+                    </table>
+                {{/if}}
+            {{/if}}
         </div>
     </div>
 </div>

--- a/client/app/templates/collection/index.hbs
+++ b/client/app/templates/collection/index.hbs
@@ -16,10 +16,10 @@
                         <button class="btn btn-info" {{action 'toggleOrganizeMode'}}>Organize Items </button>
                     {{/if}}
                     <div class="btn-group">
-                        <button class="btn {{if (eq view 'cards') 'btn-info' 'btn-default'}}"  {{action 'changeView' 'cards'}}>
-                          <i class="fa fa-th"></i>
+                        <button class="btn {{if cardView 'btn-info' 'btn-default'}}" {{action 'changeView' true}}>
+                            <i class="fa fa-th"></i>
                         </button>
-                        <button class="btn {{if (eq view 'table') 'btn-info' 'btn-default'}}" {{action 'changeView' 'table'}}>
+                        <button class="btn {{unless cardView 'btn-info' 'btn-default'}}" {{action 'changeView' false}}>
                             <i class="fa fa-list"></i>
                         </button>
                     </div>
@@ -28,27 +28,26 @@
         </div>
         <div class="row">
             {{#if list}}
-                {{#if (eq view 'table')}}
-                <table class="table table-striped">
-                    <thead>
-                        <tr>
-                            <th>Title</th>
-                            <th>Type</th>
-                            <th>Status</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {{#each list as |item|}}
-                            {{collection-item item=item view=view tagName='tr' toggleSelectedList=(action 'toggleSelectedList') organizeMode=organizeMode}}
-                        {{/each}}
-                    </tbody>
-                </table>
-                {{else if (eq view 'cards')}}
+                {{#if cardView}}
                     {{#each list as |item|}}
-                        {{collection-item item=item view=view toggleSelectedList=(action 'toggleSelectedList') organizeMode=organizeMode class="col-sm-6 col-lg-4"}}
-                {{/each}}
+                        {{collection-item item=item cardView=cardView toggleSelectedList=(action 'toggleSelectedList') organizeMode=organizeMode class="col-sm-6 col-lg-4"}}
+                    {{/each}}
+                {{else}}
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>Title</th>
+                                <th>Type</th>
+                                <th>Status</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {{#each list as |item|}}
+                                {{collection-item item=item cardView=cardView tagName='tr' toggleSelectedList=(action 'toggleSelectedList') organizeMode=organizeMode}}
+                            {{/each}}
+                        </tbody>
+                    </table>
                 {{/if}}
-
             {{else}}
                 <p class="text-center text-muted p-xl"> You do not have any items yet. You can add more using the form above.</p>
             {{/if}}

--- a/client/app/templates/collection/index.hbs
+++ b/client/app/templates/collection/index.hbs
@@ -39,6 +39,7 @@
                                 <th>Title</th>
                                 <th>Type</th>
                                 <th>Status</th>
+                                <th></th>
                             </tr>
                         </thead>
                         <tbody>

--- a/client/app/templates/collection/index.hbs
+++ b/client/app/templates/collection/index.hbs
@@ -15,6 +15,14 @@
                     {{else}}
                         <button class="btn btn-info" {{action 'toggleOrganizeMode'}}>Organize Items </button>
                     {{/if}}
+                    <div class="btn-group">
+                        <button class="btn {{if (eq view 'cards') 'btn-info' 'btn-default'}}"  {{action 'changeView' 'cards'}}>
+                          <i class="fa fa-th"></i>
+                        </button>
+                        <button class="btn {{if (eq view 'table') 'btn-info' 'btn-default'}}" {{action 'changeView' 'table'}}>
+                            <i class="fa fa-list"></i>
+                        </button>
+                    </div>
                 </div>
             {{/if}}
         </div>

--- a/client/app/templates/collection/index.hbs
+++ b/client/app/templates/collection/index.hbs
@@ -20,9 +20,27 @@
         </div>
         <div class="row">
             {{#if list}}
-                {{#each list as |item|}}
-                    {{collection-item item=item toggleSelectedList=(action 'toggleSelectedList') organizeMode=organizeMode class="col-sm-6 col-lg-4"}}
+                {{#if (eq view 'table')}}
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th>Title</th>
+                            <th>Type</th>
+                            <th>Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {{#each list as |item|}}
+                            {{collection-item item=item view=view tagName='tr' toggleSelectedList=(action 'toggleSelectedList') organizeMode=organizeMode}}
+                        {{/each}}
+                    </tbody>
+                </table>
+                {{else if (eq view 'cards')}}
+                    {{#each list as |item|}}
+                        {{collection-item item=item view=view toggleSelectedList=(action 'toggleSelectedList') organizeMode=organizeMode class="col-sm-6 col-lg-4"}}
                 {{/each}}
+                {{/if}}
+
             {{else}}
                 <p class="text-center text-muted p-xl"> You do not have any items yet. You can add more using the form above.</p>
             {{/if}}


### PR DESCRIPTION
Add ability to change view of collection contents from the default "cards" view to a list of groups and items. 

Default view:  
![screen shot 2017-03-30 at 2 40 17 pm](https://cloud.githubusercontent.com/assets/6414394/24521056/b750484a-1558-11e7-8059-ff0cb1e2a847.png)

List view:
![screen shot 2017-03-30 at 2 40 29 pm](https://cloud.githubusercontent.com/assets/6414394/24521063/bebcdeb8-1558-11e7-8757-b312801b0c79.png)

List view in organize mode:
![screen shot 2017-03-30 at 2 40 50 pm](https://cloud.githubusercontent.com/assets/6414394/24521077/cc773fda-1558-11e7-94bd-cbf723e1a6b6.png)
