### PR TITLE
Fix grouping items [OC-57]

### DIFF
--- a/client/app/components/browse-list/component.js
+++ b/client/app/components/browse-list/component.js
@@ -65,7 +65,7 @@ export default Ember.Component.extend({
                 });
 
                 // remove items that were put into the group;
-                let list = this.get('list');
+                let list = this.get('model.items');
                 list.removeObjects(selected);
                 this.send('clearSelected');
                 this.send('clearModals');


### PR DESCRIPTION
After moving an item into a group and clicking on the group, when navigating back to the collection browse page the item will still appear in the collection.

Changes:
When an item is moved into a group, remove the item from `model.items` (not `list`, which is a computed property). 