### PR TITLE
Improve selection ui for choosing collection type

### DIFF
--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -81,6 +81,17 @@ ul.comma-list {
 .pointer {
     cursor: pointer;
 }
+.coll-radio {
+    width: 24px;
+    height: 24px;
+    position: absolute;
+    border: 2px solid #ccc;
+    border-radius: 12px;
+    margin-top: -2px;
+}
+.coll-active>.coll-radio {
+    background-color:#ccc;
+}
 
 /* Home */
 

--- a/client/app/templates/create.hbs
+++ b/client/app/templates/create.hbs
@@ -18,7 +18,10 @@
                 <div class="row">
                     {{#each typeList as |type|}}
                         <div class="col-xs-3 text-center">
-                            <div class="pointer m-b-md p-md box-round {{if (eq selectedType type) 'osf-box-dk' 'osf-box'}} " {{action 'updateType' type}}> {{type}}</div>
+                            <div class="pointer m-b-md p-md box-round osf-box {{if (eq selectedType type) 'osf-box-lt coll-active' 'osf-box'}} " {{action 'updateType' type}}>
+                                <div class="coll-radio"></div>
+                                {{type}}
+                            </div>
                         </div>
                     {{/each}}
                 </div>


### PR DESCRIPTION
## Purpose
This change improves the perception of single type option while maintaining the affordances of using boxes for the purpose. 

### New look
<img width="1006" alt="screen shot 2017-04-12 at 4 26 28 pm" src="https://cloud.githubusercontent.com/assets/1314003/24977979/02f6102e-1f9d-11e7-940d-47f6be289ea8.png">

### Old look
<img width="1021" alt="screen shot 2017-04-12 at 4 28 32 pm" src="https://cloud.githubusercontent.com/assets/1314003/24978029/2342a284-1f9d-11e7-810d-a315dd06ac3b.png">

