### PR TITLE
Fix popovers in authors component [OC-86]

### DIFF
--- a/client/app/components/preprint-form-authors/component.js
+++ b/client/app/components/preprint-form-authors/component.js
@@ -89,6 +89,11 @@ export default Ember.Component.extend( NodeActionsMixin, {
             this.set('node', result);
         });
     },
+    elementsLoaded: Ember.observer('isOpen', function(){
+        if(this.get('isOpen')){
+          Ember.run.once(this.get('applyPopovers').bind(this));
+        }
+    }),
     /**
      * findContributors method.  Queries APIv2 users endpoint on any of a set of name fields.  Fetches specified page of results.
      *
@@ -282,32 +287,31 @@ export default Ember.Component.extend( NodeActionsMixin, {
             }
         }
     },
-    // TODO find alternative to jquery selectors. Temporary popover content for authors page.
-    didInsertElement: function() {
+    applyPopovers(){
         this.$('#permissions-popover').popover({
-            container: 'body',
-            content: '<dl>' +
-                '<dt>Read</dt>' +
-                    '<dd><ul><li>View preprint</li></ul></dd>' +
-                '<dt>Read + Write</dt>' +
-                    '<dd><ul><li>Read privileges</li> ' +
-                        '<li>Add and configure preprint</li> ' +
-                        '<li>Add and edit content</li></ul></dd>' +
-                '<dt>Administrator</dt><dd><ul>' +
-                    '<li>Read and write privileges</li>' +
-                    '<li>Manage authors</li>' +
-                    '<li>Public-private settings</li></ul></dd>' +
-                '</dl>'
+          container: 'body',
+          content: '<dl>' +
+          '<dt>Read</dt>' +
+          '<dd><ul><li>View preprint</li></ul></dd>' +
+          '<dt>Read + Write</dt>' +
+          '<dd><ul><li>Read privileges</li> ' +
+          '<li>Add and configure preprint</li> ' +
+          '<li>Add and edit content</li></ul></dd>' +
+          '<dt>Administrator</dt><dd><ul>' +
+          '<li>Read and write privileges</li>' +
+          '<li>Manage authors</li>' +
+          '<li>Public-private settings</li></ul></dd>' +
+          '</dl>'
         });
         this.$('#bibliographic-popover').popover({
-            container: 'body',
-            content: 'Only checked authors will be included in preprint citations. ' +
-            'Authors not in the citation can read and modify the preprint as normal.'
+          container: 'body',
+          content: 'Only checked authors will be included in preprint citations. ' +
+          'Authors not in the citation can read and modify the preprint as normal.'
         });
         this.$('#author-popover').popover({
-            container: 'body',
-            content: 'Preprints must have at least one registered administrator and one author showing in the citation at all times.  ' +
-            'A registered administrator is a user who has both confirmed their account and has administrator privileges.'
+          container: 'body',
+          content: 'Preprints must have at least one registered administrator and one author showing in the citation at all times.  ' +
+          'A registered administrator is a user who has both confirmed their account and has administrator privileges.'
         });
     },
 

--- a/client/app/components/preprint-form-authors/template.hbs
+++ b/client/app/components/preprint-form-authors/template.hbs
@@ -87,15 +87,15 @@
                   <th class="contrib-column-header">
                     {{t "components.preprint-form-authors.authors.permissions"}}
                     <span>
-                                    <i class="fa fa-question-circle permission-info"
-                                       data-toggle="popover"
-                                       data-title="{{t "components.preprint-form-authors.authors.permission_info"}}"
-                                       data-trigger="hover"
-                                       data-html="true"
-                                       data-placement="bottom"
-                                       id="permissions-popover">
-                                    </i>
-                                </span>
+                          <i class="fa fa-question-circle permission-info"
+                             data-toggle="popover"
+                             data-title="{{t "components.preprint-form-authors.authors.permission_info"}}"
+                             data-trigger="hover"
+                             data-html="true"
+                             data-placement="bottom"
+                             id="permissions-popover">
+                          </i>
+                      </span>
                     <br>
                   </th>
                   <th class="bib-padding">


### PR DESCRIPTION
## Purpose
The authors component has three popovers enabled using jquery but the original code from preprints was used didInsertElement which did not work in our current implementation. This fix makes the application of popovers through an observer to apply popover once when isOpen is true; 

https://openscience.atlassian.net/browse/OC-86