### PR TITLE
Fix authors listed as undefined [OC-90]

### DIFF
--- a/client/app/models/user.js
+++ b/client/app/models/user.js
@@ -4,7 +4,5 @@ export default DS.Model.extend({
     username: DS.attr('string'),
     firstName: DS.attr('string'),
     lastName: DS.attr('string'),
-    fullName: Ember.computed('firstName', 'lastName', function() {
-      return `${this.get('firstName')} ${this.get('lastName')}`;
-    })
+    fullName: DS.attr('string')
 });

--- a/client/app/templates/collection/edit.hbs
+++ b/client/app/templates/collection/edit.hbs
@@ -40,7 +40,7 @@
             {{/each}}
         </div>
         <p>Type: {{model.settings.collectionType}}</p>
-        <p>Created by: {{model.createdBy.fullName}}</p>
+        <p>Created by: {{model.createdBy.firstName}} {{model.createdBy.lastName}}</p>
         <p>Date created: {{model.dateCreated}} </p>
         <p>Date updated : {{model.dateUpdated}}</p>
         <p>Settings : {{settingsString}}</p>


### PR DESCRIPTION
Purpose: 
The authors in the authors section of the preprint form are all listed as "undefined"

Changes:
Add `fullName` string field to user model so that when `node.contributors.users` are loaded, the fullName property gets set. Previously, this was a computed property on the model based on `firstName` and `lastName` but the OSF data for users does not include those fields. 