### PR TITLE
Save collection settings as object [OC-92]

### DIFF
--- a/client/app/controllers/create.js
+++ b/client/app/controllers/create.js
@@ -10,7 +10,7 @@ export default Ember.Controller.extend({
             let collection = this.store.createRecord('collection', {
                 title: this.get('title'),
                 tags: '',
-                settings: JSON.stringify({ collectionType : this.get('selectedType')}),
+                settings: {collectionType: this.get('selectedType')},
                 description: this.get('description')
             });
             collection.save().then(record => {


### PR DESCRIPTION
Save the default collection settings as an object when creating a new collection, since it will be
stored as a JSON field in the database.