### PR TITLE
Make item table header css customizable [OC-118]

### DIFF
--- a/app/components/item-table/component.js
+++ b/app/components/item-table/component.js
@@ -1,5 +1,9 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-
+    theadStyle: Ember.computed('layout', function() {
+        const headerColor = this.get('layout.header_color') ? this.get('layout.header_color') : this.get('branding.colors.primary');
+        const textColor = this.get('layout.text_color') ? this.get('layout.text_color') : this.get('branding.colors.text');
+        return Ember.String.htmlSafe(`background-color: ${headerColor}; color: ${textColor};`);
+    })
 });

--- a/app/components/item-table/template.hbs
+++ b/app/components/item-table/template.hbs
@@ -1,7 +1,7 @@
 <div class="container">
     <div class="row m-b-lg">
         <table class="coll-table">
-            <thead>
+            <thead style="{{theadStyle}}">
                 <tr>
                     <th>Title</th>
                     <th>Author</th>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -101,10 +101,6 @@ ul.comma-list {
     border-bottom: none;
     box-shadow: 0 2px 12px -5px #ccc;
     width: 100%;
-    thead {
-        background-color: #00BCD4;
-        color: #fff;
-    }
     td, th {
         padding: 10px;
         p {

--- a/public/samples/sample3.json
+++ b/public/samples/sample3.json
@@ -35,7 +35,9 @@
       "type": "meeting-schedule"
     },
     {
-      "type": "item-table"
+      "type": "item-table",
+      "header_color": "#444",
+      "text_color": "#fff"
     },
     {
       "type": "landing-sponsors",


### PR DESCRIPTION
Allow users to specify `header_color` and `text_color` for collection table header css. And default to branding primary and text colors if not specified.