### PR TITLE
Fix navbar collapse bug [OC-114]

### DIFF
--- a/app/components/collection-nav/template.hbs
+++ b/app/components/collection-nav/template.hbs
@@ -1,9 +1,3 @@
-<style>
-    .icon-bar {
-        background-color: #fff;
-    }
-</style>
-
 <div class="coll-navbar" style="background-color:{{model.settings.branding.colors.primary}}">
     <div class="container">
         <div class="coll-navbar-inner">

--- a/app/components/collection-nav/template.hbs
+++ b/app/components/collection-nav/template.hbs
@@ -1,20 +1,33 @@
+<style>
+    .icon-bar {
+        background-color: #fff;
+    }
+</style>
+
 <div class="coll-navbar" style="background-color:{{model.settings.branding.colors.primary}}">
     <div class="container">
         <div class="coll-navbar-inner">
             <div class="navbar-header">
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#myNavbar">
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
                 {{#link-to "collection" model.id class="navbar-brand"}}{{model.title}}{{/link-to}}
             </div>
-            <div class="navbar navbar-right">
-                <ul class="nav navbar-nav">
-                  {{#if session.isAuthenticated}}
-                      <li>{{#link-to "collection.add"}}Add content {{/link-to}}</li>
-                  {{/if}}
-                    <li>{{#link-to "collection.browse"}} Browse {{/link-to}}</li>
-                    <li>{{#link-to "collection.search"}} Search {{/link-to}}</li>
-                  {{#if session.isAuthenticated}}
-                    <li>{{#link-to "collection.edit"}} Edit{{/link-to}}</li>
-                  {{/if}}
-                </ul>
+            <div class="collapse navbar-collapse" id="myNavbar">
+                <div class="navbar navbar-right">
+                    <ul class="nav navbar-nav">
+                        {{#if session.isAuthenticated}}
+                            <li>{{#link-to "collection.add"}}Add content {{/link-to}}</li>
+                        {{/if}}
+                        <li>{{#link-to "collection.browse"}} Browse {{/link-to}}</li>
+                        <li>{{#link-to "collection.search"}} Search {{/link-to}}</li>
+                        {{#if session.isAuthenticated}}
+                            <li>{{#link-to "collection.edit"}} Edit{{/link-to}}</li>
+                        {{/if}}
+                    </ul>
+                </div>
             </div>
         </div>
     </div>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -54,9 +54,7 @@ body {
 .modal.in {
     display: block;
 }
-.navbar{
-    height: 50px;
-}
+
 ul.comma-list {
     display: inline;
     list-style: none;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -579,6 +579,10 @@ span.sortable-bars:hover {
   }
 }
 
+.icon-bar {
+  background-color: #fff;
+}
+
 .contrib-column-header {
   padding-left: 12px;
 }


### PR DESCRIPTION
Previously, neither navbar would collapse properly - the OSF navbar, when the dropdown is toggled, would not fill in the dropdown's background, and the collections navbar had no dropdown option: the menu remained permanently open (with no background-fill) with no way to hide it. This fixes both of those problems.