### PR TITLE
Fix item-detail-page [OC-138]

### DIFF
--- a/app/components/item-detail-page/component.js
+++ b/app/components/item-detail-page/component.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { itemClasses } from 'collections/utils/itemClasses';
+import itemClasses from 'collections/utils/itemClasses';
 
 export default Ember.Component.extend({
     store: Ember.inject.service(),
@@ -10,7 +10,7 @@ export default Ember.Component.extend({
         this.set('constructedItem', itemClasses[type].create({
             session: this.get('session'),
             store: this.get('store'),
-            item: this.get('item'),
+            item: this.get('item')
         }));
-    },
+    }
 });

--- a/app/utils/itemClasses.js
+++ b/app/utils/itemClasses.js
@@ -175,4 +175,6 @@ export default {
     project: Project,
     preprint: Preprint,
     registration: Registration,
+    presentation: Project, // TODO: Look at different detail pages for event and presentation items, but for now use project detail page
+    event: Project
 };


### PR DESCRIPTION
- Fix importing itemClasses
- Add 'event' and 'presentation' item as keys in itemClasses that map to the Project item class for now (can replace later to show a different detail page for events and/or presentations)