### PR TITLE
Standardize section and layer styling

### DIFF
--- a/app/components/item-table/component.js
+++ b/app/components/item-table/component.js
@@ -11,6 +11,7 @@ export default Ember.Component.extend({
     totalPages: 1,
     searchInput: '',
     pageNumberButtons:'',
+    tagName: 'section',
     theadStyle: Ember.computed('layout', function () {
         const headerColor = this.get('layout.background_color') ? this.get('layout.background_color') : this.get('branding.colors.primary');
         const textColor = this.get('layout.text_color') ? this.get('layout.text_color') : this.get('branding.colors.text');

--- a/app/components/landing-board/component.js
+++ b/app/components/landing-board/component.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
     tagName: 'section',
+    attributeBindings: ['style'],
     listColumns: Ember.computed('layout', function() {
         const dataSource = this.get('layout.data');
         const list = this.get('model.settings').data[dataSource];
@@ -11,7 +12,7 @@ export default Ember.Component.extend({
         column.right = list;
         return column;
     }),
-    containerStyle: Ember.computed('branding.colors', function() {
+    style: Ember.computed('branding.colors', function() {
         return Ember.String.htmlSafe(`background-color: ${this.get('branding.colors.background')}; color: ${this.get('branding.colors.backgroundText')}`);
     }),
 });

--- a/app/components/landing-board/template.hbs
+++ b/app/components/landing-board/template.hbs
@@ -1,4 +1,4 @@
-<div class="landing-board-wrapper p-xl" style="{{containerStyle}}">
+<div class="landing-board-wrapper p-xl">
     <div class="container">
         <h2> {{layout.title}}</h2>
         <div class="row">

--- a/app/components/landing-hero/component.js
+++ b/app/components/landing-hero/component.js
@@ -3,12 +3,13 @@ import Ember from 'ember';
 export default Ember.Component.extend({
     session: Ember.inject.service(),
     tagName: 'section',
+    attributeBindings: ['style'],
     searchQuery: '',
     data: Ember.computed('layout', function() {
         const dataSource = this.get('layout.data');
         return this.get('model.settings').data[dataSource];
     }),
-    containerStyle: Ember.computed('branding.colors', function() {
+    style: Ember.computed('branding.colors', function() {
         return Ember.String.htmlSafe(`background-color: ${this.get('branding.colors.background')}; color: ${this.get('branding.colors.backgroundText')}`);
     }),
     logoStyle: Ember.computed('branding.logo', function() {

--- a/app/components/landing-hero/template.hbs
+++ b/app/components/landing-hero/template.hbs
@@ -1,4 +1,4 @@
-<div class="landing-hero-container p-xl" style="{{containerStyle}}">
+<div class="landing-hero-container p-xl">
     <div class="container">
        <div class="row">
            <div class="text-center m-t-lg col-xs-12">

--- a/app/components/landing-paragraph/component.js
+++ b/app/components/landing-paragraph/component.js
@@ -3,7 +3,8 @@ import Ember from 'ember';
 export default Ember.Component.extend({
     session: Ember.inject.service(),
     tagName: 'section',
-    containerStyle: Ember.computed('layout', function() {
+    attributeBindings: ['style'],
+    style: Ember.computed('layout', function() {
         return Ember.String.htmlSafe(`background-color: ${this.get('layout.background-color')}; color: ${this.get('layout.text-color')}`);
     }),
     logoStyle: Ember.computed('branding.logo', function() {

--- a/app/components/landing-paragraph/template.hbs
+++ b/app/components/landing-paragraph/template.hbs
@@ -1,7 +1,6 @@
-<div id="{{get-section-id layout.title}}" class="landing-paragraph-container p-xl"
-     style="{{containerStyle}}">
+<div id="{{get-section-id layout.title}}" class="landing-paragraph-container">
     <div class="container">
-        <div class="row wrapper">
+        <div class="row">
             {{#if layout.title}}
                 <h2>
                     {{layout.title}}

--- a/app/components/landing-splash-image/component.js
+++ b/app/components/landing-splash-image/component.js
@@ -3,7 +3,8 @@ import Ember from 'ember';
 export default Ember.Component.extend({
     session: Ember.inject.service(),
     tagName: 'section',
-    imageStyle: Ember.computed('layout', function () {
+    attributeBindings: ['style'],
+    style: Ember.computed('layout', function () {
         const url = this.get('layout.img-url') ? `url(${this.get('layout.img-url')})` : 'url(\'/img/splash-default.jpg\')';
         const height = this.get('layout.height') ? `${this.get('layout.height')}px` : '300px';
         return `background: ${url} no-repeat left center; ` +

--- a/app/components/landing-splash-image/template.hbs
+++ b/app/components/landing-splash-image/template.hbs
@@ -1,4 +1,2 @@
-<div class="splash-container p-xl" style="{{imageStyle}}">
-    <div class="container">
-    </div>
+<div class="splash-container p-xl">
 </div>

--- a/app/components/landing-sponsors/component.js
+++ b/app/components/landing-sponsors/component.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
     tagName: 'section',
-    containerStyle: Ember.computed('layout', function() {
+    attributeBindings: ['style'],
+    style: Ember.computed('layout', function() {
         const bg = this.get('layout.background-color') ? this.get('layout.background-color') : this.get('branding.colors.background');
         const txt = this.get('layout.text-color') ? this.get('layout.text-color') : this.get('branding.colors.text');
         return Ember.String.htmlSafe(`background-color: ${bg}; color: ${txt}`);

--- a/app/components/landing-sponsors/template.hbs
+++ b/app/components/landing-sponsors/template.hbs
@@ -1,4 +1,4 @@
-<div id="{{get-section-id layout.title}}" class="p-xl" style="{{containerStyle}}">
+<div id="{{get-section-id layout.title}}" class="p-xl">
     <div class="container">
         <div class="row text-center">
             <h2 class="p-b-lg">

--- a/app/components/landing-title/component.js
+++ b/app/components/landing-title/component.js
@@ -3,7 +3,8 @@ import Ember from 'ember';
 export default Ember.Component.extend({
     session: Ember.inject.service(),
     tagName: 'section',
-    containerStyle: Ember.computed('layout', 'branding', function() {
+    attributeBindings: ['style'],
+    style: Ember.computed('layout', 'branding', function() {
         // if image is specified for background, use that
         // otherwise, check if a background color has been specified.
         // if so, use that. if not, use the branding background color

--- a/app/components/landing-title/template.hbs
+++ b/app/components/landing-title/template.hbs
@@ -1,4 +1,4 @@
-<div class="landing-title-container p-xl" style="{{containerStyle}}">
+<div class="landing-title-container p-xl">
     <div class="container">
         <div class="row">
             <div class="text-center m-t-lg col-xs-12">

--- a/app/components/meeting-schedule/component.js
+++ b/app/components/meeting-schedule/component.js
@@ -6,6 +6,7 @@ export default Ember.Component.extend({
     session: Ember.inject.service(),
     store: Ember.inject.service(),
     tagName: 'section',
+    attributeBindings: ['style'],
     filterString: '',
     trackFilter: '',
     roomFilter: '',
@@ -14,7 +15,7 @@ export default Ember.Component.extend({
         const dataSource = this.get('layout.data');
         return this.get('model.settings').data[dataSource];
     }),
-    containerStyle: Ember.computed('layout', function() {
+    style: Ember.computed('layout', function() {
         const bg = this.get('layout.background_color') ? `background-color:${this.get('layout.background_color')};` : '';
         const txt = this.get('layout.text_color') ? `color: ${this.get('layout.text_color')};` : '';
         return Ember.String.htmlSafe(bg + txt);

--- a/app/components/meeting-schedule/template.hbs
+++ b/app/components/meeting-schedule/template.hbs
@@ -1,4 +1,4 @@
-<div class="meetings-schedule-container p-lg" style="{{containerStyle}}">
+<div class="meetings-schedule-container p-lg">
     <div class="container">
         <div class="row">
             <div class="col-sm-6">

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -239,6 +239,7 @@ a.dropdown-toggle.nav-user-dropdown {
 .navbar-nav > li > a {
     padding-bottom: 14px;
 }
+
 /* Collection Toolbar - it has filtering only now*/
 .coll-toolbar {
     padding-top: 50px;
@@ -267,6 +268,22 @@ a.dropdown-toggle.nav-user-dropdown {
     background: #ffffff;
     margin: 15px 15px;
     min-height:200px;
+    display: flex;
+    flex-direction: column;
+
+    .card-content { flex: 1 0 auto; }
+    footer { margin: 0; }
+
+    .btn {
+        align-self: flex-end;
+        float: right;
+        margin: -5px auto auto 10px;
+    }
+
+    h3 {
+        margin-top: 6px;
+        padding-bottom: 5px;
+    }
 }
 .coll-add-item {
     padding: 20px;
@@ -349,7 +366,6 @@ tr.item-row-selected {
             z-index: 3;
             position: relative;
             border-bottom: none;
-            border-radius: 2px;
             &.active{
                 background: #fff;
                 z-index: 9;
@@ -386,8 +402,6 @@ tr.item-row-selected {
 /* Item detail */
 .coll-item-header {
     background-color: $dark-banner;
-    /*background: url('/img/triangle.jpg') top center;
-    background-size: cover;*/
     padding: 25px 0;
     color: #fff;
 
@@ -513,13 +527,7 @@ tr.item-row-selected {
             opacity: 1;
         }
     }
-    // THESE STYLES ARE INTERFERING WITH MY STYLES.
-    // .row {
-    //     margin: 0;
-    // }
-    // label, input, textarea {
-    //     display: block;
-    // }
+
     label > input, label > textarea {
         font-weight: normal;
     }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -33,8 +33,11 @@ h2:hover >.headerlink {
 }
 
 h2 {
-    padding: 30px;
-    padding-top: 50px;
+}
+
+section {
+    padding-top: 30px;
+    padding-bottom: 30px;
 }
 
 .info {

--- a/app/styles/components/file-grid.scss
+++ b/app/styles/components/file-grid.scss
@@ -1,6 +1,4 @@
 .file-grid-container {
-  margin-top: 50px;
-  margin-bottom: 50px;
 
   .item-thumbnail {
     width: 100%;

--- a/app/styles/components/landing-paragraph.scss
+++ b/app/styles/components/landing-paragraph.scss
@@ -1,12 +1,12 @@
 .landing-paragraph-container {
-  .wrapper {
-    max-width: 1250px;
-    margin-left: auto;
-    margin-right: auto;
-  }
   p {
     text-align: justify;
     text-justify: inter-word;
     word-break: break-all;
+
+    max-width: 1250px;
+    margin-left: auto;
+    margin-right: auto;
   }
+  padding: 30px;
 }

--- a/app/templates/collections/collection/index.hbs
+++ b/app/templates/collections/collection/index.hbs
@@ -1,6 +1,5 @@
 {{#if model.settings.layers}}
     {{#each model.settings.layers as |view index|}}
-
         {{component view.component
                     model=model
                     collection=collection


### PR DESCRIPTION
This commit moves most component styling to the ember-generated container for each component, allowing for the use of the html5 <section> element. Inline style variables are removed. A standardized padding is introduced to every section.