### PR TITLE
Add 'show-in-nav: true' to settings to show in menu

### DIFF
--- a/app/components/section-menu/component.js
+++ b/app/components/section-menu/component.js
@@ -48,10 +48,11 @@ export default Ember.Component.extend({
                 return {
                     section: section,
                     label: section["section-header"],
-                    id: "section-" + index
-                }
+                    id: "section-" + index,
+                    nav: section["settings.show-on-nav"]
+                };
             })
-            .filter((menuItem, index) => index > this.get("index"));
+            .filter((menuItem) => menuItem.section['settings']['show-in-nav']);
     }),
 
     actions: {

--- a/app/components/section-menu/component.js
+++ b/app/components/section-menu/component.js
@@ -48,11 +48,10 @@ export default Ember.Component.extend({
                 return {
                     section: section,
                     label: section["section-header"],
-                    id: "section-" + index,
-                    nav: section["settings.show-on-nav"]
+                    id: "section-" + index
                 };
             })
-            .filter((menuItem) => menuItem.section['settings']['show-in-nav']);
+            .filter((menuItem) => !menuItem.section['settings']['hide-from-nav']);
     }),
 
     actions: {


### PR DESCRIPTION
Sections are no longer included in nav menu by default. Add to nav menu by including `"show-in-nav": true` in the section's settings JSON.