### PR TITLE
Remove case numbers

### DIFF
--- a/app/components/case-list-item/template.hbs
+++ b/app/components/case-list-item/template.hbs
@@ -1,4 +1,3 @@
-<div class="case-no">{{case.id}}</div>
 <div class="form-type">{{partial (await caseDescriptionTemplate)}}</div>
 <div class="continue-button">
     <a class="btn btn-success pull-right" {{action "continueCase" case collection}}>Continue</a>

--- a/app/templates/collections/collection/submissions.hbs
+++ b/app/templates/collections/collection/submissions.hbs
@@ -12,7 +12,6 @@
 
 <div class="active-cases">
     <div class="table-heading" style="background-color: #444; color: #fff;">
-        <div class="case-no">Case No.</div>
         <div class="form-type">Form Type</div>
         <div class="continue-button"></div>
     </div>


### PR DESCRIPTION
Remove the case numbers column from the submissions table. It adds no useful information, and a description of each case should replace it.